### PR TITLE
Adds instance-level list_instance_organization_memberships endpoint

### DIFF
--- a/src/apis/organization_memberships_api.rs
+++ b/src/apis/organization_memberships_api.rs
@@ -149,6 +149,51 @@ impl OrganizationMembership {
 		}
 	}
 
+	/// Retrieves all organization memberships across the entire instance
+	pub async fn list_instance_organization_memberships(
+		clerk_client: &Clerk,
+		limit: Option<u64>,
+		offset: Option<u64>,
+	) -> Result<crate::models::OrganizationMemberships, Error<ListOrganizationMembershipsError>> {
+		let local_var_configuration = &clerk_client.config;
+
+		let local_var_client = &local_var_configuration.client;
+
+		let local_var_uri_str = format!(
+			"{}/organization_memberships",
+			local_var_configuration.base_path,
+		);
+		let mut local_var_req_builder = local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
+
+		if let Some(ref local_var_str) = limit {
+			local_var_req_builder = local_var_req_builder.query(&[("limit", &local_var_str.to_string())]);
+		}
+		if let Some(ref local_var_str) = offset {
+			local_var_req_builder = local_var_req_builder.query(&[("offset", &local_var_str.to_string())]);
+		}
+		if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
+			local_var_req_builder = local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+		}
+
+		let local_var_req = local_var_req_builder.build()?;
+		let local_var_resp = local_var_client.execute(local_var_req).await?;
+
+		let local_var_status = local_var_resp.status();
+		let local_var_content = local_var_resp.text().await?;
+
+		if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+			serde_json::from_str(&local_var_content).map_err(Error::from)
+		} else {
+			let local_var_entity: Option<ListOrganizationMembershipsError> = serde_json::from_str(&local_var_content).ok();
+			let local_var_error = ResponseContent {
+				status: local_var_status,
+				content: local_var_content,
+				entity: local_var_entity,
+			};
+			Err(Error::ResponseError(local_var_error))
+		}
+	}
+
 	/// Retrieves all user memberships for the given organization
 	pub async fn list_organization_memberships(
 		clerk_client: &Clerk,


### PR DESCRIPTION
## Summary
- Adds `list_instance_organization_memberships()` to `OrganizationMembership` that calls `GET /organization_memberships` (instance-level, no org ID in path)
- Supports `limit`/`offset` pagination, returns the same `OrganizationMemberships` response type
- Will be used by the Gitar scheduler for bulk admin email resolution across all orgs without per-org API calls

## Test plan
- Verified `cargo check` passes
- Will be integration-tested via the audience sync scheduler job in the main Gitar repo