### PR TITLE
Fix JWT validation for Clerk tokens with non-string header fields

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ name = "rocket"
 path = "examples/rocket.rs"
 required-features = ["rocket"]
 
+[[example]]
+name = "jwt_debug"
+path = "examples/jwt_debug.rs"
+
 [lib]
 doctest = false
 
@@ -42,7 +46,7 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
 regex = "1.10.6"
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+jsonwebtoken = { git = "ssh://git@github.com/gitarcode/jsonwebtoken.git", rev = "497fdb4", default-features = false, features = ["use_pem", "rust_crypto"] }
 futures-util = "0.3.28"
 actix-rt = { version = "2.10.0", optional = true }
 actix-web = { version = "4.9.0", optional = true }
@@ -63,6 +67,7 @@ features = ["json", "multipart"]
 [dev-dependencies]
 base64 = "0.22.1"
 clerk-rs = { path = "../clerk-rs" }
+env_logger = "0.11"
 mockito = "1.4.0"
 rand = "0.8.5"
 rsa = "0.9.6"

--- a/examples/jwt_debug.rs
+++ b/examples/jwt_debug.rs
@@ -1,0 +1,52 @@
+use clerk_rs::{
+	clerk::Clerk,
+	validators::{authorizer::validate_jwt, jwks::MemoryCacheJwksProvider},
+	ClerkConfiguration,
+};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	env_logger::init();
+
+	let secret_key = std::env::var("CLERK_SECRET_KEY").expect("CLERK_SECRET_KEY must be set");
+	let token = std::env::args().nth(1).expect("Usage: jwt_debug <jwt-token>");
+
+	// Decode and print header for debugging
+	let parts: Vec<&str> = token.split('.').collect();
+	if parts.len() >= 2 {
+		use base64::engine::{general_purpose::URL_SAFE_NO_PAD, Engine};
+		if let Ok(header_bytes) = URL_SAFE_NO_PAD.decode(parts[0]) {
+			println!("Header: {}", String::from_utf8_lossy(&header_bytes));
+		}
+		if let Ok(payload_bytes) = URL_SAFE_NO_PAD.decode(parts[1]) {
+			println!("Payload: {}", String::from_utf8_lossy(&payload_bytes));
+		}
+	}
+
+	let config = ClerkConfiguration::new(None, None, Some(secret_key), None);
+	let client = Clerk::new(config);
+	let jwks_provider = Arc::new(MemoryCacheJwksProvider::new(client));
+
+	println!("\nValidating JWT...");
+	match validate_jwt(&token, jwks_provider).await {
+		Ok(jwt) => {
+			println!("SUCCESS: JWT validated");
+			println!("  sub: {}", jwt.sub);
+			println!("  iss: {}", jwt.iss);
+			println!("  exp: {}", jwt.exp);
+			println!("  version: {:?}", jwt.version);
+			if let Some(ref org) = jwt.org {
+				println!("  org_id: {}", org.id);
+			}
+			if let Some(ref org_v2) = jwt.org_v2 {
+				println!("  org_v2.id: {}", org_v2.id);
+			}
+		}
+		Err(e) => {
+			println!("FAILED: {e:?}");
+		}
+	}
+
+	Ok(())
+}

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -58,7 +58,7 @@ pub struct ClerkJwt {
 	pub exp: i32,
 	pub iat: i32,
 	pub iss: String,
-	pub nbf: i32,
+	pub nbf: Option<i32>,
 	pub sid: Option<String>,
 	pub sub: String,
 	pub act: Option<Actor>,
@@ -202,8 +202,7 @@ pub fn validate_jwt_with_key(token: &str, key: &JwksKey) -> Result<ClerkJwt, Cle
 
 /// Extract the header from a jwt token
 fn get_token_header(token: &str) -> Result<Header, jwtError> {
-	let header = decode_header(&token);
-	header
+	decode_header(token)
 }
 
 #[cfg(test)]
@@ -404,7 +403,7 @@ mod tests {
 			iat: current_time as i32,
 			exp: (current_time + 1000) as i32,
 			iss: "issuer".to_string(),
-			nbf: current_time as i32,
+			nbf: Some(current_time as i32),
 			sid: Some("session_id".to_string()),
 			act: Some(Actor {
 				iss: Some("actor_iss".to_string()),
@@ -560,7 +559,7 @@ mod tests {
 			iat: current_time as i32,
 			exp: (current_time + 1000) as i32,
 			iss: "issuer".to_string(),
-			nbf: current_time as i32,
+			nbf: Some(current_time as i32),
 			sid: Some("session_id".to_string()),
 			act: Some(Actor {
 				iss: Some("actor_iss".to_string()),
@@ -717,7 +716,7 @@ mod tests {
 			iat: current_time as i32,
 			exp: (current_time + 1000) as i32,
 			iss: "issuer".to_string(),
-			nbf: current_time as i32,
+			nbf: Some(current_time as i32),
 			sid: Some("session_id".to_string()),
 			act: Some(Actor {
 				iss: Some("actor_iss".to_string()),


### PR DESCRIPTION
## Summary

Fixes JWT validation failures caused by Clerk adding `oiat` (integer) and `cat` (string) fields to JWT headers.

- **Root cause**: jsonwebtoken v10's `Header.extras` is typed as `HashMap<String, String>`, which rejects non-string values during deserialization. Clerk's new `oiat` field is an integer, causing `decode_header()` and `decode()` to fail before signature validation even begins.
- **Fix**: Use gitarcode/jsonwebtoken fork ([`497fdb4`](https://github.com/gitarcode/jsonwebtoken/commit/497fdb4)) that changes `extras` to `HashMap<String, serde_json::Value>` (cherry-pick of upstream [Keats/jsonwebtoken#496](https://github.com/Keats/jsonwebtoken/pull/496))
- Cherry-pick upstream clerk-rs [PR #282](https://github.com/DarrenBaldwin07/clerk-rs/pull/282) (jsonwebtoken v9→v10)
- Cherry-pick upstream clerk-rs [PR #280](https://github.com/DarrenBaldwin07/clerk-rs/pull/280) (make `nbf` optional)
- Add `jwt_debug` example for local JWT validation testing
